### PR TITLE
feature: wait for rds_instances to be deleted

### DIFF
--- a/aws/leftovers.go
+++ b/aws/leftovers.go
@@ -107,12 +107,10 @@ func NewLeftovers(logger logger, accessKeyId, secretAccessKey, sessionToken, reg
 
 			ec2.NewKeyPairs(ec2Client, logger),
 			ec2.NewInstances(ec2Client, logger, resourceTags),
-			ec2.NewSecurityGroups(ec2Client, logger, resourceTags),
 			ec2.NewTags(ec2Client, logger),
 			ec2.NewVolumes(ec2Client, logger),
 			ec2.NewNetworkInterfaces(ec2Client, logger),
 			ec2.NewNatGateways(ec2Client, logger),
-			ec2.NewVpcs(ec2Client, logger, routeTables, subnets, internetGateways, resourceTags),
 			ec2.NewImages(ec2Client, stsClient, logger, resourceTags),
 			ec2.NewAddresses(ec2Client, logger),
 			ec2.NewSnapshots(ec2Client, stsClient, logger),
@@ -120,6 +118,7 @@ func NewLeftovers(logger logger, accessKeyId, secretAccessKey, sessionToken, reg
 			s3.NewBuckets(s3Client, logger, bucketManager),
 
 			rds.NewDBInstances(rdsClient, logger),
+			ec2.NewSecurityGroups(ec2Client, logger, resourceTags),
 			rds.NewDBSubnetGroups(rdsClient, logger),
 			rds.NewDBClusters(rdsClient, logger),
 
@@ -128,6 +127,7 @@ func NewLeftovers(logger logger, accessKeyId, secretAccessKey, sessionToken, reg
 
 			route53.NewHostedZones(route53Client, logger, recordSets),
 			route53.NewHealthChecks(route53Client, logger),
+			ec2.NewVpcs(ec2Client, logger, routeTables, subnets, internetGateways, resourceTags),
 		},
 	}, nil
 }

--- a/aws/rds/db_instance.go
+++ b/aws/rds/db_instance.go
@@ -33,6 +33,14 @@ func (d DBInstance) Delete() error {
 		return fmt.Errorf("Delete: %s", err)
 	}
 
+	err = d.client.WaitUntilDBInstanceDeleted(&awsrds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: d.name,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Delete: %s", err)
+	}
+
 	return nil
 }
 

--- a/aws/rds/db_instances.go
+++ b/aws/rds/db_instances.go
@@ -11,6 +11,7 @@ import (
 type dbInstancesClient interface {
 	DescribeDBInstances(*awsrds.DescribeDBInstancesInput) (*awsrds.DescribeDBInstancesOutput, error)
 	DeleteDBInstance(*awsrds.DeleteDBInstanceInput) (*awsrds.DeleteDBInstanceOutput, error)
+	WaitUntilDBInstanceDeleted(input *awsrds.DescribeDBInstancesInput) error
 }
 
 type DBInstances struct {

--- a/aws/rds/fakes/db_instances_client.go
+++ b/aws/rds/fakes/db_instances_client.go
@@ -31,6 +31,17 @@ type DbInstancesClient struct {
 		}
 		Stub func(*awsrds.DescribeDBInstancesInput) (*awsrds.DescribeDBInstancesOutput, error)
 	}
+	WaitUntilDBInstanceDeletedCall struct {
+		sync.Mutex
+		CallCount int
+		Receives  struct {
+			Input *awsrds.DescribeDBInstancesInput
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func(*awsrds.DescribeDBInstancesInput) error
+	}
 }
 
 func (f *DbInstancesClient) DeleteDBInstance(param1 *awsrds.DeleteDBInstanceInput) (*awsrds.DeleteDBInstanceOutput, error) {
@@ -52,4 +63,14 @@ func (f *DbInstancesClient) DescribeDBInstances(param1 *awsrds.DescribeDBInstanc
 		return f.DescribeDBInstancesCall.Stub(param1)
 	}
 	return f.DescribeDBInstancesCall.Returns.DescribeDBInstancesOutput, f.DescribeDBInstancesCall.Returns.Error
+}
+func (f *DbInstancesClient) WaitUntilDBInstanceDeleted(param1 *awsrds.DescribeDBInstancesInput) error {
+	f.WaitUntilDBInstanceDeletedCall.Lock()
+	defer f.WaitUntilDBInstanceDeletedCall.Unlock()
+	f.WaitUntilDBInstanceDeletedCall.CallCount++
+	f.WaitUntilDBInstanceDeletedCall.Receives.Input = param1
+	if f.WaitUntilDBInstanceDeletedCall.Stub != nil {
+		return f.WaitUntilDBInstanceDeletedCall.Stub(param1)
+	}
+	return f.WaitUntilDBInstanceDeletedCall.Returns.Error
 }

--- a/gcp/compute/fakes/networks_client.go
+++ b/gcp/compute/fakes/networks_client.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	compute "google.golang.org/api/compute/v1"
+	gcpcompute "google.golang.org/api/compute/v1"
 )
 
 type NetworksClient struct {
@@ -22,10 +22,10 @@ type NetworksClient struct {
 		sync.Mutex
 		CallCount int
 		Returns   struct {
-			NetworkSlice []*compute.Network
+			NetworkSlice []*gcpcompute.Network
 			Error        error
 		}
-		Stub func() ([]*compute.Network, error)
+		Stub func() ([]*gcpcompute.Network, error)
 	}
 }
 
@@ -39,7 +39,7 @@ func (f *NetworksClient) DeleteNetwork(param1 string) error {
 	}
 	return f.DeleteNetworkCall.Returns.Error
 }
-func (f *NetworksClient) ListNetworks() ([]*compute.Network, error) {
+func (f *NetworksClient) ListNetworks() ([]*gcpcompute.Network, error) {
 	f.ListNetworksCall.Lock()
 	defer f.ListNetworksCall.Unlock()
 	f.ListNetworksCall.CallCount++

--- a/gcp/compute/fakes/target_http_proxies_client.go
+++ b/gcp/compute/fakes/target_http_proxies_client.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	gcp "google.golang.org/api/compute/v1"
+	gcpcompute "google.golang.org/api/compute/v1"
 )
 
 type TargetHttpProxiesClient struct {
@@ -22,10 +22,10 @@ type TargetHttpProxiesClient struct {
 		sync.Mutex
 		CallCount int
 		Returns   struct {
-			TargetHttpProxyList *gcp.TargetHttpProxyList
+			TargetHttpProxyList *gcpcompute.TargetHttpProxyList
 			Error               error
 		}
-		Stub func() (*gcp.TargetHttpProxyList, error)
+		Stub func() (*gcpcompute.TargetHttpProxyList, error)
 	}
 }
 
@@ -39,7 +39,7 @@ func (f *TargetHttpProxiesClient) DeleteTargetHttpProxy(param1 string) error {
 	}
 	return f.DeleteTargetHttpProxyCall.Returns.Error
 }
-func (f *TargetHttpProxiesClient) ListTargetHttpProxies() (*gcp.TargetHttpProxyList, error) {
+func (f *TargetHttpProxiesClient) ListTargetHttpProxies() (*gcpcompute.TargetHttpProxyList, error) {
 	f.ListTargetHttpProxiesCall.Lock()
 	defer f.ListTargetHttpProxiesCall.Unlock()
 	f.ListTargetHttpProxiesCall.CallCount++

--- a/gcp/compute/fakes/target_pools_client.go
+++ b/gcp/compute/fakes/target_pools_client.go
@@ -3,7 +3,7 @@ package fakes
 import (
 	"sync"
 
-	gcp "google.golang.org/api/compute/v1"
+	gcpcompute "google.golang.org/api/compute/v1"
 )
 
 type TargetPoolsClient struct {
@@ -26,10 +26,10 @@ type TargetPoolsClient struct {
 			Region string
 		}
 		Returns struct {
-			TargetPoolList *gcp.TargetPoolList
+			TargetPoolList *gcpcompute.TargetPoolList
 			Error          error
 		}
-		Stub func(string) (*gcp.TargetPoolList, error)
+		Stub func(string) (*gcpcompute.TargetPoolList, error)
 	}
 }
 
@@ -44,7 +44,7 @@ func (f *TargetPoolsClient) DeleteTargetPool(param1 string, param2 string) error
 	}
 	return f.DeleteTargetPoolCall.Returns.Error
 }
-func (f *TargetPoolsClient) ListTargetPools(param1 string) (*gcp.TargetPoolList, error) {
+func (f *TargetPoolsClient) ListTargetPools(param1 string) (*gcpcompute.TargetPoolList, error) {
 	f.ListTargetPoolsCall.Lock()
 	defer f.ListTargetPoolsCall.Unlock()
 	f.ListTargetPoolsCall.CallCount++


### PR DESCRIPTION
  We need to wait for rds_instances to actually be deleted before
  continuing with rds subnet deletion, because you cannot delete
  a subnet that contains an instance

 Also reordered ec2 subnet and vpc deletion

Co-authored-by: Nick Rohn <nrohn@vmware.com>
Co-authored-by: Jhonathan Aristizabal <jhonathana@vmware.com>

cc: @ciriarte @alejandralara